### PR TITLE
Remove Jan Pazdziora as org-member

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -3,7 +3,6 @@ orgs:
   red-hat-data-services:
     members:
       - abhijeet-dhumal
-      - adelton
       - adrezni
       - adrielparedes
       - adysenrothman


### PR DESCRIPTION
Jan Pazdziora is no longer with Red Hat.
