### PR TITLE
chore: add syntaxsdev (Sidney Glinton) to org members

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -167,6 +167,7 @@ orgs:
       - StevenTobin
       - sthundat
       - sutaakar
+      - syntaxsdev
       - szaher
       - taneem-ibrahim
       - tarilabs


### PR DESCRIPTION
Adds syntaxsdev (Sidney Glinton) to the org members.