### PR TITLE
add 'wznoinsk' to organization_members.yaml

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -196,6 +196,7 @@ orgs:
       - varshaprasad96
       - vconzola
       - VedantMahabaleshwarkar
+      - wznoinsk
       - Xaenalt
       - Yael-F
       - yehudit1987


### PR DESCRIPTION
add 'wznoinsk' to organization members


'wznoinsk' is a member of RHOAI 
so needs access to rhds and other repos
