### PR TITLE
Adding rroshan to organization_members.yaml

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -186,6 +186,7 @@ orgs:
       - robotmaxtron
       - RomanFilip
       - rpancham
+      - rroshan-rh
       - rsun19
       - ruivieira
       - russellb


### PR DESCRIPTION
Adding rroshan-rh (myself) to the RHOAI organization

## Description
Adding rroshan-rh (myself) to the organization by updating the organization_members.yaml file
