### PR TITLE
Update organization_members.yaml

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -10,7 +10,6 @@ orgs:
       - adysenrothman
       - agagancarczyk
       - AjayJagan
-      - ajaypratap003
       - akram
       - Al-Pragliola
       - aloganat
@@ -32,7 +31,6 @@ orgs:
       - aviavissar
       - avinashsingh77
       - bdattoma
-      - biswassri
       - Bobbins228
       - bobbravo2
       - brettmthompson
@@ -144,7 +142,6 @@ orgs:
       - manosnoam
       - ManuelaAnsaldo
       - MarianMacik
-      - mattmahoneyrh
       - maxamillion
       - mholder6
       - MichaelClifford
@@ -230,7 +227,6 @@ orgs:
       - Yael-F
       - yehudit1987
       - Ygnas
-      - ykaliuta
       - YosiElias
       - YuliaKrimerman
       - zdtsw

--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -95,7 +95,6 @@ orgs:
       - ikeola13
       - isinyaaa
       - israel-hdez
-      - jackdelahunt
       - jarcher
       - jctanner
       - jedemo


### PR DESCRIPTION
Removing org members that left RHOAI/ODH:
More specifically removing the following members:
Matt Mahoney
Yauheni Kaliuta
Srijoni Biswas
Ajay Pratap


