### PR TITLE
Add schimuneck to organization members

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -198,6 +198,7 @@ orgs:
       - russellb
       - saichandrapandraju
       - sanandpa
+      - schimuneck
       - sefroberg
       - senanz
       - shgriffi


### PR DESCRIPTION
Request to add my GitHub username (schimuneck) to the red-hat-data-services organization.
